### PR TITLE
ingestStreams: make position optional and dont pass it when setting mode to auto

### DIFF
--- a/services/encoding_service.go
+++ b/services/encoding_service.go
@@ -98,9 +98,23 @@ func (s *EncodingService) RetrieveCustomData(id string) (*models.CustomDataRespo
 // not part of the original bitmovin API
 func (s *EncodingService) AddIngestStream(encodingID string, name string, inputID string, inputPath string,
 	selectionMode bitmovintypes.SelectionMode, position int) (*models.StreamResponse, error) {
-
-	b := []byte(fmt.Sprintf(`{"name" : %q, "inputId" : %q, "inputPath": %q, "selectionMode": %q, "position": %d}`,
-		name, inputID, inputPath, selectionMode, position))
+	ingestStream := struct {
+		Name          string `json:"name"`
+		InputID       string `json:"inputId"`
+		InputPath     string `json:"inputPath"`
+		SelectionMode string `json:"selectionMode"`
+		Position      *int   `json:"position,omitempty"`
+	}{
+		Name:          name,
+		InputID:       inputID,
+		InputPath:     inputPath,
+		SelectionMode: string(selectionMode),
+		Position:      &position,
+	}
+	if selectionMode == bitmovintypes.SelectionModeAuto {
+		ingestStream.Position = nil // dont pass position when the selection mode is AUTO
+	}
+	b, err := json.Marshal(ingestStream)
 
 	path := EncodingEndpoint + "/" + encodingID + "/" + "input-streams" + "/" + "ingest"
 	o, err := s.RestService.Create(path, b)


### PR DESCRIPTION
Fixes these warnings
```
Check IngestInputStream 58b35bd9-3a44-4492-90c5-47dd610154f6: 
"position" should not be set when using selectionMode "AUTO". 
Position (0) will be ignored.
```