### PR TITLE
Vs 550/bitmovin reprioritize

### DIFF
--- a/services/rest_service.go
+++ b/services/rest_service.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/streamco/bitmovin-go/bitmovin"
@@ -137,7 +138,12 @@ func (r *RestService) Delete(relativeURL string) ([]byte, error) {
 
 // TODO default value version
 func (r *RestService) List(relativeURL string, offset int64, limit int64) ([]byte, error) {
-	queryParams := fmt.Sprintf("?offset=%v&limit=%v", offset, limit)
+	var queryParams string
+	if strings.Contains(relativeURL, "?") {
+		queryParams = fmt.Sprintf("&offset=%v&limit=%v", offset, limit)
+	} else {
+		queryParams = fmt.Sprintf("?offset=%v&limit=%v", offset, limit)
+	}
 	fullURL := *r.Bitmovin.APIBaseURL + relativeURL + queryParams
 
 	req, err := http.NewRequest("GET", fullURL, nil)

--- a/services/rest_service.go
+++ b/services/rest_service.go
@@ -135,7 +135,7 @@ func (r *RestService) Delete(relativeURL string) ([]byte, error) {
 	return body, nil
 }
 
-//TODO default value version
+// TODO default value version
 func (r *RestService) List(relativeURL string, offset int64, limit int64) ([]byte, error) {
 	queryParams := fmt.Sprintf("?offset=%v&limit=%v", offset, limit)
 	fullURL := *r.Bitmovin.APIBaseURL + relativeURL + queryParams
@@ -212,6 +212,7 @@ func (r *RestService) Update(relativeURL string, input []byte) ([]byte, error) {
 	}
 	req, err := http.NewRequest("PUT", fullURL, bytes.NewBuffer(input))
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("X-Api-Key", *r.Bitmovin.APIKey)
 	if r.Bitmovin.OrganizationID != nil {
 		req.Header.Set("X-Tenant-Org-Id", *r.Bitmovin.OrganizationID)
@@ -246,7 +247,9 @@ func unmarshalError(body []byte) (*models.DataEnvelope, error) {
 	var d models.DataEnvelope
 	err := json.Unmarshal(body, &d)
 	if err != nil {
-		return nil, err
+		// instead of bubbling the unmarshall error, let us return back the actual message so that it is not lost
+		d.Data.Message = fmt.Sprintf("unmarshall failed with error %s, this is the actual body: %s", err.Error(), string(body))
+		return &d, nil
 	}
 	return &d, nil
 }


### PR DESCRIPTION
In the transcoder we have code that calls bitmovin `reprioritize` and they all are failing with an error around the lines of 
```
invalid character 'U' looking for beginning of value
```

The transcode job `priority` is actually taken from the column `media.priority` and not from `job.priority` (which I assumed earlier). I am not sure actually how that value is `set`. Maybe @robertoamici would know more (I tried searching)


This means the response of the command is not a JSON. We are not able to know why the command has failed (as it is now masked with this error). This fix will help us with that to know why the command failed. I did few things here (one reason could be because it is not in state `queue` but in state `created` when we set the priority). Once we know the actual reason why it fails then we might need more changes to address it.

* I set the accept-type to `json`. We only accept JSON, this is being explicit
* If the error cannot be unmarshalled properly then I store the raw text in the error DTO struct
